### PR TITLE
Add sysinfo to discovered bulbs

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -36,6 +36,10 @@ const scan = Bulb.scan()
       const jsonMsg = JSON.parse(decryptedMsg)
       const sysinfo = jsonMsg.system.get_sysinfo
 
+      if (sysinfo.mic_type !== 'IOT.SMARTBULB') {
+        return
+      }
+
       const light = new Bulb(rinfo.address)
       light._info = rinfo
       light._sysinfo = sysinfo

--- a/src/lib.js
+++ b/src/lib.js
@@ -32,8 +32,18 @@ const scan = Bulb.scan()
       client.send(msgBuf, 0, msgBuf.length, 9999, '255.255.255.255')
     })
     client.on('message', (msg, rinfo) => {
+      const decryptedMsg = this.decrypt(msg).toString('ascii')
+      const jsonMsg = JSON.parse(decryptedMsg)
+      const sysinfo = jsonMsg.system.get_sysinfo
+
       const light = new Bulb(rinfo.address)
       light._info = rinfo
+      light._sysinfo = sysinfo
+      light.host = rinfo.address
+      light.port = rinfo.port
+      light.name = sysinfo.alias
+      light.deviceId = sysinfo.deviceId
+
       emitter.emit('light', light)
     })
     emitter.stop = () => client.close()
@@ -266,4 +276,3 @@ const decrypted = Bulb.decrypt(encrypted)
     return Bulb.decrypt(buffer, key)
   }
 }
-

--- a/src/lib.js
+++ b/src/lib.js
@@ -9,6 +9,7 @@ module.exports = class Bulb {
   /**
    * Scan for lightbulbs on your network
    * @module scan
+   * @param {Boolean} onlyBulbs Exclude devices not identified as bulbs
    * @return {EventEmitter} Emit `light` events when lightbulbs are found
    * @example
 ```js
@@ -23,7 +24,7 @@ const scan = Bulb.scan()
   })
 ```
    */
-  static scan () {
+  static scan (onlyBulbs = false) {
     const emitter = new EventEmitter()
     const client = dgram.createSocket('udp4')
     client.bind(9998, undefined, () => {
@@ -36,7 +37,7 @@ const scan = Bulb.scan()
       const jsonMsg = JSON.parse(decryptedMsg)
       const sysinfo = jsonMsg.system.get_sysinfo
 
-      if (sysinfo.mic_type !== 'IOT.SMARTBULB') {
+      if (onlyBulbs && sysinfo.mic_type !== 'IOT.SMARTBULB') {
         return
       }
 


### PR DESCRIPTION
Adds `sysinfo` to bulbs, and ignores other TP-Link IOT devices (e.g. smart plugs) that are discovered.

I've only tested with LB120, and don't have other bulbs yet. I am hoping that the `sysinfo` structure is similar across other bulb models, but the TP-Link smart plugs have a different key on the device type (`sysinfo.type` instead of `sysinfo.mic_type`), so I'm slightly concerned about inadvertently ignoring other bulb models if they're also different. Thoughts? I need access to some `sysinfo` values in a package I wrote using this ([homebridge-tplink-lightbulb](https://github.com/leematt/homebridge-tplink-lightbulb)), but could do the filtering on that end instead.