### PR TITLE
Set reuseAddr in udp socket

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -26,7 +26,10 @@ const scan = Bulb.scan()
    */
   static scan (filter) {
     const emitter = new EventEmitter()
-    const client = dgram.createSocket('udp4')
+    const client = dgram.createSocket({
+      type: 'udp4',
+      reuseAddr: true
+    });
     client.bind(9998, undefined, () => {
       client.setBroadcast(true)
       const msgBuf = Bulb.encrypt(new Buffer('{"system":{"get_sysinfo":{}}}'))


### PR DESCRIPTION
This allows multiple scans to coexist without conflict. Notably, if a
buggy program crashes with a scan in progress, it will be possible to
restart that program without having to care about the dangling socket.