### PR TITLE
Ability to change LED status light

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -162,8 +162,31 @@ light.power(true)
             .then(r => r['smartlife.iot.smartbulb.lightingservice'].transition_light_state)
         }
       })
-  }
+  } 
+  /**
+     * Set led-state of lightbulb
+     * @module led
+     * @param {Boolean} ledState On or off
+     * @returns {Promise}          Resolves to output of command
+     * @example
+     * ```js
+    // turn the LED status light on
+    const light = new TPLSmartDevice('10.0.0.200')
+    light.led(true)
+    .then(status => {
+      console.log(status)
+    })
+    .catch(err => console.error(err))
+    ```
+     */
 
+  }, {
+    key: "led",
+    value: function led (ledState = true) {
+      return this.send({
+        system: { set_led_off: { off: ledState ? 0 : 1 }}
+      })
+    }
   /**
    * Get schedule info
    * @module daystat


### PR DESCRIPTION
You can now power on or off the status lights on TP-Link devices (only tested this with the HS100)