### PR TITLE
Beginning of WiFi management

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -73,6 +73,26 @@ const scan = TPLSmartDevice.scan()
         .then(r => r['smartlife.iot.common.softaponboarding'].get_scaninfo.ap_list)
   }
 
+  /**
+   * Connects the device to the access point in the parameters
+   * @param ssid {String}
+   * @param psswd {String}
+   * @param keyType {Number}
+   * @param cypherType {Number}
+   * @returns {Promise}          Resolves to output of command
+   */
+  connectwifi(ssid, psswd, keyType, cypherType){
+    return this.send({'smartlife.iot.common.softaponboarding': {
+        'set_stainfo':{
+          'cypher_type': cypherType,
+          'key_type': keyType,
+          'password': psswd,
+          'ssid': ssid
+        }
+      }})
+        .then(r => r['smartlife.iot.common.softaponboarding']).set_stainfo
+  }
+
 
   /**
    * Get info about the TPLSmartDevice

--- a/src/lib.js
+++ b/src/lib.js
@@ -61,6 +61,20 @@ const scan = TPLSmartDevice.scan()
   }
 
   /**
+   * Scans the wifi networks in range of the device
+   * @returns {Promise}          Resolves to output of command
+   */
+  listwifi () {
+    return this.send({'smartlife.iot.common.softaponboarding': {
+      'get_scaninfo':{
+        'refresh': 1
+      }
+      }})
+        .then(r => r['smartlife.iot.common.softaponboarding'].get_scaninfo.ap_list)
+  }
+
+
+  /**
    * Get info about the TPLSmartDevice
    * @module info
    * @return {Promise} Resolves to info


### PR DESCRIPTION
Solves #55

By adding the ability to control the WiFi features of the devices, the need for the Kasa App is completely removed for the setup process. I will try to add 3 features, both in the library and the cli:

- List AP in range of the device
- Connect to one AP
- Unpair the device with the current AP